### PR TITLE
feat: build Videobalancer cinema frontend

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -1,177 +1,407 @@
-.app {
+.appShell {
   min-height: 100vh;
   display: flex;
   flex-direction: column;
+  background: radial-gradient(circle at top, #0f172a 0%, #020617 45%, #0b1120 100%);
+  color: #e2e8f0;
 }
 
-.header {
-  background: #ffffff;
-  border-bottom: 1px solid rgba(15, 23, 42, 0.08);
-  padding: 16px 24px;
+.appHeader {
+  padding: 48px clamp(24px, 6vw, 72px) 32px;
+  display: flex;
+  justify-content: center;
+  text-align: center;
+}
+
+.appHeader h1 {
+  font-size: clamp(32px, 4vw, 48px);
+  margin-bottom: 12px;
+  color: #f8fafc;
+}
+
+.appHeader p {
+  max-width: 640px;
+  margin: 0 auto;
+  line-height: 1.6;
+  color: rgba(226, 232, 240, 0.8);
+}
+
+.filtersSection {
+  padding: 0 clamp(24px, 5vw, 72px);
+}
+
+.filtersForm {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 18px;
+  padding: 24px clamp(20px, 4vw, 40px);
+  border-radius: 24px;
+  background: rgba(15, 23, 42, 0.75);
+  backdrop-filter: blur(18px);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.fieldGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.fieldGroup label {
+  font-size: 13px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.fieldGroup input,
+.fieldGroup select {
+  padding: 12px 14px;
+  border-radius: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(15, 23, 42, 0.8);
+  color: #f8fafc;
+  font-size: 15px;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.fieldGroup input:focus,
+.fieldGroup select:focus {
+  outline: none;
+  border-color: rgba(129, 140, 248, 0.8);
+  box-shadow: 0 0 0 3px rgba(129, 140, 248, 0.25);
+}
+
+.formActions {
+  display: flex;
+  gap: 12px;
+  align-items: flex-end;
+}
+
+.primaryButton,
+.ghostButton {
+  padding: 12px 20px;
+  border-radius: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  border: none;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.primaryButton {
+  background: linear-gradient(135deg, #6366f1, #8b5cf6);
+  color: #f8fafc;
+  box-shadow: 0 15px 35px -15px rgba(99, 102, 241, 0.65);
+}
+
+.primaryButton:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 40px -18px rgba(99, 102, 241, 0.8);
+}
+
+.ghostButton {
+  background: rgba(148, 163, 184, 0.08);
+  color: rgba(226, 232, 240, 0.8);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.ghostButton:hover {
+  transform: translateY(-1px);
+  border-color: rgba(148, 163, 184, 0.4);
+}
+
+.contentSection {
+  display: grid;
+  grid-template-columns: minmax(0, 360px) minmax(0, 1fr);
+  gap: clamp(20px, 4vw, 36px);
+  padding: clamp(30px, 5vw, 60px);
+  flex: 1;
+}
+
+.listColumn,
+.detailsColumn {
+  background: rgba(15, 23, 42, 0.72);
+  border-radius: 28px;
+  padding: clamp(20px, 4vw, 36px);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  backdrop-filter: blur(18px);
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.sectionTitleRow {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 24px;
-}
-
-.brand {
-  font-size: 20px;
-  font-weight: 700;
-  color: #1f2933;
-}
-
-.nav {
-  display: flex;
-  align-items: center;
   gap: 12px;
 }
 
-.nav a {
-  text-decoration: none;
-  padding: 8px 14px;
+.sectionTitleRow h2 {
+  margin: 0;
+  font-size: 22px;
+  color: #f8fafc;
+}
+
+.statusTag {
+  font-size: 13px;
+  padding: 6px 12px;
   border-radius: 999px;
-  color: #4b5563;
-  transition: all 0.2s ease;
+  background: rgba(129, 140, 248, 0.18);
+  color: rgba(129, 140, 248, 0.95);
 }
 
-.nav a.active,
-.nav a:hover {
-  background: #ff7043;
-  color: #ffffff;
-}
-
-.headerActions {
-  display: flex;
+.catalogGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
   gap: 16px;
-  align-items: center;
 }
 
-.main {
-  flex: 1;
-  padding: 32px 24px 48px;
-}
-
-.content {
-  max-width: 960px;
-  margin: 0 auto;
+.catalogCard {
+  position: relative;
+  border: none;
+  border-radius: 22px;
+  padding: 0;
+  overflow: hidden;
+  background: rgba(15, 23, 42, 0.6);
+  color: inherit;
+  cursor: pointer;
+  text-align: left;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+  border: 1px solid rgba(148, 163, 184, 0.15);
   display: flex;
   flex-direction: column;
-  gap: 24px;
+  height: 100%;
 }
 
-.card {
-  background: #ffffff;
-  border-radius: 16px;
-  padding: 24px;
-  box-shadow: 0 15px 35px -25px rgba(15, 23, 42, 0.45);
-  border: 1px solid rgba(15, 23, 42, 0.05);
+.catalogCard:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 20px 40px -25px rgba(15, 23, 42, 0.85);
+  border-color: rgba(129, 140, 248, 0.4);
 }
 
-.cardTitle {
-  margin: 0 0 12px;
-  font-size: 20px;
+.catalogCard.active {
+  border-color: rgba(129, 140, 248, 0.9);
+  box-shadow: 0 22px 50px -25px rgba(99, 102, 241, 0.65);
 }
 
-.cardSubtitle {
-  margin: 0 0 20px;
-  color: #64748b;
+.catalogCard.skeleton {
+  pointer-events: none;
+  background: linear-gradient(120deg, rgba(30, 41, 59, 0.7), rgba(51, 65, 85, 0.7));
+  min-height: 240px;
+  animation: pulse 1.6s ease-in-out infinite;
 }
 
-.sectionTitle {
-  margin: 0 0 16px;
+@keyframes pulse {
+  0% {
+    opacity: 0.6;
+  }
+  50% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0.6;
+  }
 }
 
-.table {
+.posterThumb {
+  position: relative;
   width: 100%;
-  border-collapse: collapse;
+  aspect-ratio: 2 / 3;
+  overflow: hidden;
+  background: rgba(30, 41, 59, 0.8);
 }
 
-.table th,
-.table td {
-  padding: 12px;
-  text-align: left;
-  border-bottom: 1px solid rgba(15, 23, 42, 0.06);
+.posterThumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
 }
 
-.table th {
-  font-weight: 600;
-  background: rgba(15, 23, 42, 0.02);
-}
-
-.actionsRow {
+.posterFallback {
+  position: absolute;
+  inset: 0;
   display: flex;
-  gap: 8px;
-  flex-wrap: wrap;
-  margin-top: 16px;
-}
-
-.button {
-  background: #ff7043;
-  border: none;
-  border-radius: 10px;
-  color: #ffffff;
-  padding: 10px 18px;
-  font-weight: 600;
-  display: inline-flex;
   align-items: center;
-  gap: 8px;
-  transition: background 0.2s ease;
+  justify-content: center;
+  font-size: 13px;
+  color: rgba(226, 232, 240, 0.7);
+  background: linear-gradient(135deg, rgba(99, 102, 241, 0.18), rgba(79, 70, 229, 0.25));
 }
 
-.button.secondary {
-  background: rgba(15, 23, 42, 0.08);
-  color: #1f2933;
-}
-
-.button:disabled {
-  opacity: 0.6;
-  cursor: not-allowed;
-}
-
-.inputRow {
+.cardContent {
+  padding: 16px 18px 20px;
   display: flex;
-  flex-wrap: wrap;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.cardContent h3 {
+  margin: 0;
+  font-size: 17px;
+  font-weight: 600;
+}
+
+.muted {
+  color: rgba(226, 232, 240, 0.6);
+}
+
+.smallText {
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.emptyState {
+  padding: 20px;
+  border-radius: 18px;
+  background: rgba(15, 23, 42, 0.65);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  color: rgba(226, 232, 240, 0.78);
+}
+
+.detailsCard {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.detailsHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+}
+
+.detailsHeader h3 {
+  margin: 0;
+  font-size: 26px;
+  color: #f8fafc;
+}
+
+.ratings {
+  display: flex;
+  gap: 8px;
+}
+
+.ratingBadge {
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: rgba(56, 189, 248, 0.18);
+  color: #38bdf8;
+  font-weight: 600;
+  font-size: 13px;
+}
+
+.metaGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 12px 18px;
+}
+
+.metaRow {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  background: rgba(15, 23, 42, 0.5);
+  padding: 12px 14px;
+  border-radius: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.12);
+}
+
+.metaLabel {
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: rgba(148, 163, 184, 0.85);
+}
+
+.metaValue {
+  font-size: 15px;
+  color: #f8fafc;
+}
+
+.description {
+  margin: 0;
+  line-height: 1.7;
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.translations {
+  display: flex;
+  flex-direction: column;
   gap: 12px;
 }
 
-.inputRow input,
-.inputRow select,
-.inputRow textarea {
-  padding: 10px 12px;
-  border-radius: 10px;
-  border: 1px solid rgba(15, 23, 42, 0.12);
-  min-width: 200px;
+.translationChips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
 }
 
-.badge {
+.chip {
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 999px;
+  padding: 8px 14px;
+  background: rgba(15, 23, 42, 0.6);
+  color: rgba(226, 232, 240, 0.8);
+  cursor: pointer;
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  padding: 6px 10px;
-  border-radius: 999px;
-  background: rgba(255, 112, 67, 0.12);
-  color: #ff7043;
-  font-size: 13px;
-  font-weight: 600;
+  transition: border-color 0.2s ease, background 0.2s ease, color 0.2s ease;
 }
 
-.grid {
-  display: grid;
-  gap: 16px;
+.chip.active {
+  border-color: rgba(129, 140, 248, 0.9);
+  background: rgba(99, 102, 241, 0.3);
+  color: #f8fafc;
 }
 
-@media (max-width: 900px) {
-  .header {
-    flex-direction: column;
-    align-items: flex-start;
+.chip:hover {
+  border-color: rgba(129, 140, 248, 0.6);
+}
+
+.chipSub {
+  font-size: 12px;
+  opacity: 0.75;
+}
+
+.playerWrapper {
+  position: relative;
+  padding-top: 56.25%;
+  border-radius: 22px;
+  overflow: hidden;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  background: rgba(15, 23, 42, 0.65);
+}
+
+.playerWrapper iframe {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  border: none;
+  background: #000;
+}
+
+@media (max-width: 1200px) {
+  .contentSection {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 720px) {
+  .filtersForm {
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    padding: 20px;
   }
 
-  .headerActions {
-    width: 100%;
-    flex-wrap: wrap;
+  .formActions {
+    justify-content: stretch;
   }
 
-  .nav {
-    flex-wrap: wrap;
+  .formActions button {
+    flex: 1;
   }
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,91 +1,391 @@
-import { NavLink, Route, Routes } from "react-router-dom";
-import { useMemo } from "react";
-import { MenuPage } from "@/pages/MenuPage";
-import { CartPage } from "@/pages/CartPage";
-import { AddressesPage } from "@/pages/AddressesPage";
-import { OrdersPage } from "@/pages/OrdersPage";
-import { AdminPage } from "@/pages/AdminPage";
-import { LoginPanel } from "@/components/LoginPanel";
-import { AdminSecretPanel } from "@/components/AdminSecretPanel";
-import { useCartStore } from "@/store/cart";
-import { useAuthStore } from "@/store/auth";
+import { FormEvent, useEffect, useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import {
+  buildLookupFromItem,
+  fetchMediaDetails,
+  fetchMediaList,
+  getMediaKey,
+} from "@/api/videobalancer";
+import type { MediaItem, MediaTranslationOption } from "@/types/videobalancer";
 import "./App.css";
 
-function ProtectedRoute({ children }: { children: React.ReactNode }) {
-  const customerId = useAuthStore((state) => state.customerId);
+const CATEGORY_OPTIONS = [
+  { value: "movie", label: "Фильмы" },
+  { value: "serial", label: "Сериалы" },
+  { value: "anime", label: "Аниме" },
+  { value: "anime-serial", label: "Аниме-сериалы" },
+  { value: "tv-show", label: "TV-шоу" },
+] as const;
 
-  if (!customerId) {
-    return (
-      <div className="card">
-        <h2 className="cardTitle">Требуется вход</h2>
-        <p className="cardSubtitle">
-          Войдите по номеру телефона вверху, чтобы получить доступ к этой странице.
-        </p>
-      </div>
-    );
-  }
+const TEST_IFRAME_SRC = "https://api.apbugall.org/iframe/test";
 
-  return <>{children}</>;
+type CategoryValue = (typeof CATEGORY_OPTIONS)[number]["value"];
+
+interface SearchFilters {
+  name: string;
+  year: string;
+  category: CategoryValue;
 }
 
 export default function App() {
-  const items = useCartStore((state) => state.items);
-
-  const cartCount = useMemo(
-    () => items.reduce((sum, item) => sum + item.quantity, 0),
-    [items]
+  const [filters, setFilters] = useState<SearchFilters>({
+    name: "",
+    year: "",
+    category: "movie",
+  });
+  const [appliedFilters, setAppliedFilters] = useState<SearchFilters>(filters);
+  const [selectedKey, setSelectedKey] = useState<string | null>(null);
+  const [selectedTranslationId, setSelectedTranslationId] = useState<string | null>(
+    null
   );
+
+  const mediaListQuery = useQuery({
+    queryKey: ["mediaList", appliedFilters],
+    queryFn: () =>
+      fetchMediaList({
+        list: appliedFilters.category,
+        name: appliedFilters.name || undefined,
+        year: appliedFilters.year || undefined,
+        order: "date",
+      }),
+  });
+
+  const items = mediaListQuery.data ?? [];
+
+  useEffect(() => {
+    if (!items.length) {
+      if (selectedKey !== null) {
+        setSelectedKey(null);
+      }
+      return;
+    }
+
+    if (selectedKey) {
+      const exists = items.some((item) => getMediaKey(item) === selectedKey);
+      if (exists) {
+        return;
+      }
+    }
+
+    const firstKey = getMediaKey(items[0]);
+    setSelectedKey(firstKey);
+  }, [items, selectedKey]);
+
+  const selectedItem = useMemo(() => {
+    if (!selectedKey) {
+      return null;
+    }
+    return items.find((item) => getMediaKey(item) === selectedKey) ?? null;
+  }, [items, selectedKey]);
+
+  const mediaDetailsQuery = useQuery({
+    queryKey: ["mediaDetails", selectedKey],
+    queryFn: () => fetchMediaDetails(buildLookupFromItem(selectedItem!)),
+    enabled: Boolean(selectedItem),
+  });
+
+  const fullDetails: MediaItem | null = mediaDetailsQuery.data ?? selectedItem ?? null;
+
+  const translationEntries = useMemo(() => {
+    const translationMap = fullDetails?.translation_iframe ?? null;
+
+    if (!translationMap) {
+      return [] as Array<[string, MediaTranslationOption]>;
+    }
+
+    return Object.entries(translationMap).filter(
+      ([, option]) => Boolean(option?.iframe || option?.name)
+    ) as Array<[string, MediaTranslationOption]>;
+  }, [fullDetails]);
+
+  useEffect(() => {
+    if (!translationEntries.length) {
+      if (selectedTranslationId !== null) {
+        setSelectedTranslationId(null);
+      }
+      return;
+    }
+
+    if (
+      selectedTranslationId &&
+      translationEntries.some(([id]) => id === selectedTranslationId)
+    ) {
+      return;
+    }
+
+    setSelectedTranslationId(translationEntries[0][0]);
+  }, [translationEntries, selectedTranslationId]);
+
+  const activeIframe = useMemo(() => {
+    if (selectedTranslationId && fullDetails?.translation_iframe) {
+      const option = fullDetails.translation_iframe[selectedTranslationId];
+      if (option?.iframe) {
+        return option.iframe;
+      }
+    }
+
+    if (fullDetails?.iframe) {
+      return fullDetails.iframe;
+    }
+
+    return TEST_IFRAME_SRC;
+  }, [fullDetails, selectedTranslationId]);
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setAppliedFilters(filters);
+  };
+
+  const handleReset = () => {
+    const resetValue: SearchFilters = { name: "", year: "", category: "movie" };
+    setFilters(resetValue);
+    setAppliedFilters(resetValue);
+  };
+
+  const handleSelectItem = (item: MediaItem) => {
+    const key = getMediaKey(item);
+    setSelectedKey(key);
+  };
 
   return (
-    <div className="app">
-      <header className="header">
-        <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
-          <span className="brand">RestorNew</span>
-          <span style={{ color: "#64748b", fontSize: 13 }}>
-            Онлайн-заказы для клиентов и администраторов
-          </span>
-        </div>
-        <nav className="nav">
-          <NavLink to="/" end>
-            Меню
-          </NavLink>
-          <NavLink to="/cart">
-            Корзина{cartCount > 0 ? ` (${cartCount})` : ""}
-          </NavLink>
-          <NavLink to="/addresses">Адреса</NavLink>
-          <NavLink to="/orders">Мои заказы</NavLink>
-          <NavLink to="/admin">Админ</NavLink>
-        </nav>
-        <div className="headerActions">
-          <LoginPanel />
-          <AdminSecretPanel />
+    <div className="appShell">
+      <header className="appHeader">
+        <div>
+          <h1>Videobalancer Cinema</h1>
+          <p>
+            Онлайн-кинотеатр с данными и плеером от Videobalancer. Используйте
+            поиск, чтобы найти фильм или сериал, и сразу смотрите его в плеере.
+          </p>
         </div>
       </header>
-      <main className="main">
-        <div className="content">
-          <Routes>
-            <Route index element={<MenuPage />} />
-            <Route path="/cart" element={<CartPage />} />
-            <Route
-              path="/addresses"
-              element={
-                <ProtectedRoute>
-                  <AddressesPage />
-                </ProtectedRoute>
+
+      <section className="filtersSection">
+        <form className="filtersForm" onSubmit={handleSubmit}>
+          <div className="fieldGroup">
+            <label htmlFor="name">Название</label>
+            <input
+              id="name"
+              name="name"
+              placeholder="Например, Чебурашка"
+              value={filters.name}
+              onChange={(event) =>
+                setFilters((prev) => ({ ...prev, name: event.target.value }))
               }
             />
-            <Route
-              path="/orders"
-              element={
-                <ProtectedRoute>
-                  <OrdersPage />
-                </ProtectedRoute>
+          </div>
+          <div className="fieldGroup">
+            <label htmlFor="year">Год</label>
+            <input
+              id="year"
+              name="year"
+              placeholder="2023"
+              value={filters.year}
+              onChange={(event) =>
+                setFilters((prev) => ({ ...prev, year: event.target.value }))
               }
             />
-            <Route path="/admin" element={<AdminPage />} />
-          </Routes>
+          </div>
+          <div className="fieldGroup">
+            <label htmlFor="category">Категория</label>
+            <select
+              id="category"
+              name="category"
+              value={filters.category}
+              onChange={(event) =>
+                setFilters((prev) => ({
+                  ...prev,
+                  category: event.target.value as CategoryValue,
+                }))
+              }
+            >
+              {CATEGORY_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="formActions">
+            <button type="submit" className="primaryButton">
+              Найти
+            </button>
+            <button type="button" onClick={handleReset} className="ghostButton">
+              Сбросить
+            </button>
+          </div>
+        </form>
+      </section>
+
+      <section className="contentSection">
+        <div className="listColumn">
+          <div className="sectionTitleRow">
+            <h2>Каталог</h2>
+            {mediaListQuery.isFetching ? (
+              <span className="statusTag">Обновление…</span>
+            ) : null}
+          </div>
+          {mediaListQuery.isError ? (
+            <div className="emptyState">
+              Не удалось загрузить каталог: {formatError(mediaListQuery.error)}
+            </div>
+          ) : null}
+          {!mediaListQuery.isLoading && items.length === 0 ? (
+            <div className="emptyState">Ничего не найдено</div>
+          ) : null}
+          <div className="catalogGrid">
+            {mediaListQuery.isLoading
+              ? Array.from({ length: 6 }).map((_, index) => (
+                  <div key={index} className="catalogCard skeleton" />
+                ))
+              : items.map((item) => {
+                  const key = getMediaKey(item);
+                  const isActive = key === selectedKey;
+                  const posterUrl = item.poster && item.poster !== "0" ? item.poster : null;
+
+                  return (
+                    <button
+                      key={key}
+                      type="button"
+                      className={`catalogCard${isActive ? " active" : ""}`}
+                      onClick={() => handleSelectItem(item)}
+                    >
+                      <div className="posterThumb">
+                        {posterUrl ? (
+                          <img src={posterUrl} alt="" loading="lazy" />
+                        ) : (
+                          <div className="posterFallback">Нет постера</div>
+                        )}
+                      </div>
+                      <div className="cardContent">
+                        <h3>{item.name}</h3>
+                        <p className="muted">{item.year}</p>
+                        <p className="muted smallText">
+                          {item.genre || "Жанр не указан"}
+                        </p>
+                      </div>
+                    </button>
+                  );
+                })}
+          </div>
         </div>
-      </main>
+
+        <div className="detailsColumn">
+          <div className="sectionTitleRow">
+            <h2>Информация</h2>
+            {mediaDetailsQuery.isFetching ? (
+              <span className="statusTag">Загрузка…</span>
+            ) : null}
+          </div>
+          {mediaDetailsQuery.isError ? (
+            <div className="emptyState">
+              Не удалось загрузить детали: {formatError(mediaDetailsQuery.error)}
+            </div>
+          ) : null}
+          {!fullDetails ? (
+            <div className="emptyState">Выберите фильм или сериал из каталога.</div>
+          ) : (
+            <article className="detailsCard">
+              <div className="detailsHeader">
+                <div>
+                  <h3>{fullDetails.name}</h3>
+                  {fullDetails.original_name ? (
+                    <p className="muted">{fullDetails.original_name}</p>
+                  ) : null}
+                </div>
+                {fullDetails.rating_kp || fullDetails.rating_imdb ? (
+                  <div className="ratings">
+                    {fullDetails.rating_kp ? (
+                      <span className="ratingBadge">KP {fullDetails.rating_kp}</span>
+                    ) : null}
+                    {fullDetails.rating_imdb ? (
+                      <span className="ratingBadge">IMDb {fullDetails.rating_imdb}</span>
+                    ) : null}
+                  </div>
+                ) : null}
+              </div>
+
+              <div className="metaGrid">
+                <MetaRow label="Год" value={fullDetails.year} />
+                <MetaRow label="Жанр" value={fullDetails.genre} />
+                <MetaRow label="Страна" value={fullDetails.country} />
+                <MetaRow label="Режиссеры" value={fullDetails.directors} />
+                <MetaRow label="Актеры" value={fullDetails.actors} />
+                <MetaRow label="Продюсеры" value={fullDetails.producers} />
+                <MetaRow label="Возраст" value={fullDetails.age_restrictions} />
+                <MetaRow label="Продолжительность" value={fullDetails.time} />
+              </div>
+
+              {fullDetails.description ? (
+                <p className="description">{fullDetails.description}</p>
+              ) : null}
+
+              <div className="translations">
+                <h4>Озвучки</h4>
+                {translationEntries.length === 0 ? (
+                  <p className="muted">Озвучки не указаны</p>
+                ) : (
+                  <div className="translationChips">
+                    {translationEntries.map(([id, option]) => (
+                      <button
+                        key={id}
+                        type="button"
+                        className={`chip${selectedTranslationId === id ? " active" : ""}`}
+                        onClick={() => setSelectedTranslationId(id)}
+                      >
+                        <span>{option.name}</span>
+                        {option.quality ? (
+                          <span className="chipSub">{option.quality}</span>
+                        ) : null}
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </div>
+
+              <div className="playerWrapper">
+                <iframe
+                  key={activeIframe}
+                  src={activeIframe || TEST_IFRAME_SRC}
+                  title={`Плеер ${fullDetails.name}`}
+                  loading="lazy"
+                  allow="autoplay; fullscreen"
+                  allowFullScreen
+                />
+              </div>
+            </article>
+          )}
+        </div>
+      </section>
     </div>
   );
+}
+
+interface MetaRowProps {
+  label: string;
+  value?: string | null;
+}
+
+function MetaRow({ label, value }: MetaRowProps) {
+  if (!value || value === "0") {
+    return null;
+  }
+
+  return (
+    <div className="metaRow">
+      <span className="metaLabel">{label}</span>
+      <span className="metaValue">{value}</span>
+    </div>
+  );
+}
+
+function formatError(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  if (typeof error === "string") {
+    return error;
+  }
+
+  return "Неизвестная ошибка";
 }

--- a/web/src/api/videobalancer.ts
+++ b/web/src/api/videobalancer.ts
@@ -1,0 +1,132 @@
+import type {
+  ApiResponse,
+  MediaItem,
+  MediaListParams,
+  MediaLookupParams,
+} from "@/types/videobalancer";
+
+const API_BASE_URL = "https://api.apbugall.org/";
+const API_TOKEN = "115f79b05ff195bc531a3878101ee6";
+
+function buildUrl(params: Record<string, string | undefined>) {
+  const searchParams = new URLSearchParams();
+  searchParams.set("token", API_TOKEN);
+
+  Object.entries(params).forEach(([key, value]) => {
+    if (value && value.trim()) {
+      searchParams.set(key, value.trim());
+    }
+  });
+
+  return `${API_BASE_URL}?${searchParams.toString()}`;
+}
+
+async function fetchJson<T>(url: string): Promise<T> {
+  const response = await fetch(url);
+
+  if (!response.ok) {
+    throw new Error(`Ошибка запроса: ${response.status}`);
+  }
+
+  const json = (await response.json()) as ApiResponse<T>;
+
+  if (json.status === "error") {
+    throw new Error(json.error_info || "Неизвестная ошибка API");
+  }
+
+  return json.data;
+}
+
+function normalizeMediaItems(input: unknown): MediaItem[] {
+  if (!input) {
+    return [];
+  }
+
+  if (Array.isArray(input)) {
+    return input as MediaItem[];
+  }
+
+  if (typeof input === "object") {
+    const maybeItem = input as Record<string, unknown>;
+
+    if ("name" in maybeItem && typeof maybeItem.name === "string") {
+      return [maybeItem as unknown as MediaItem];
+    }
+
+    return Object.values(maybeItem) as unknown as MediaItem[];
+  }
+
+  return [];
+}
+
+export async function fetchMediaList(params: MediaListParams): Promise<MediaItem[]> {
+  const url = buildUrl({
+    list: params.list,
+    name: params.name,
+    year: params.year,
+    order: params.order,
+    order_type: params.order_type,
+    translation_name: params.translation_name,
+    translation_id: params.translation_id,
+    country: params.country,
+    not_country: params.not_country,
+    actor: params.actor,
+    director: params.director,
+    producer: params.producer,
+    rating_kp: params.rating_kp,
+    rating_imdb: params.rating_imdb,
+    poster: params.poster,
+    description: params.description,
+    uhd: params.uhd,
+    page: params.page,
+  });
+
+  const data = await fetchJson<unknown>(url);
+  return normalizeMediaItems(data);
+}
+
+export async function fetchMediaDetails(
+  lookup: MediaLookupParams
+): Promise<MediaItem> {
+  const url = buildUrl({
+    kp: lookup.kp,
+    imdb: lookup.imdb,
+    world_art: lookup.world_art,
+    name: lookup.name,
+    year: lookup.year,
+  });
+
+  return fetchJson<MediaItem>(url);
+}
+
+export function buildLookupFromItem(item: MediaItem): MediaLookupParams {
+  if (item.id_kp && item.id_kp !== "0") {
+    return { kp: item.id_kp };
+  }
+
+  if (item.id_imdb && item.id_imdb !== "0") {
+    return { imdb: item.id_imdb };
+  }
+
+  if (item.id_world_art && item.id_world_art !== "0") {
+    return { world_art: item.id_world_art };
+  }
+
+  return {
+    name: item.name,
+    year: item.year,
+  };
+}
+
+export function getMediaKey(item: MediaItem): string {
+  if (item.id_kp && item.id_kp !== "0") {
+    return `kp:${item.id_kp}`;
+  }
+  if (item.id_imdb && item.id_imdb !== "0") {
+    return `imdb:${item.id_imdb}`;
+  }
+  if (item.id_world_art && item.id_world_art !== "0") {
+    return `world:${item.id_world_art}`;
+  }
+  return `name:${item.name}-${item.year}`;
+}

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1,28 +1,26 @@
 :root {
-  color-scheme: light;
-  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-  background-color: #f4f5f7;
-  color: #1f2933;
-}
-
-body {
-  margin: 0;
-  min-height: 100vh;
-}
-
-a {
-  color: inherit;
+  color-scheme: dark;
+  font-family: "Inter", "Manrope", system-ui, -apple-system, BlinkMacSystemFont,
+    "Segoe UI", sans-serif;
+  background-color: #020617;
+  color: #e2e8f0;
 }
 
 * {
   box-sizing: border-box;
 }
 
-button {
-  font: inherit;
-  cursor: pointer;
+body {
+  margin: 0;
+  min-height: 100vh;
+  background-color: #020617;
 }
 
+a {
+  color: inherit;
+}
+
+button,
 input,
 select,
 textarea {

--- a/web/src/types/videobalancer.ts
+++ b/web/src/types/videobalancer.ts
@@ -1,0 +1,95 @@
+export interface MediaTranslationOption {
+  iframe: string | null;
+  name: string;
+  quality: string | null;
+  adv?: boolean;
+}
+
+export interface MediaEpisodeTranslation extends MediaTranslationOption {}
+
+export interface MediaEpisode {
+  translation?: Record<string, MediaEpisodeTranslation> | null;
+  iframe?: string | null;
+  episode: string;
+}
+
+export interface MediaSeason {
+  iframe?: string | null;
+  season: string;
+  episodes?: Record<string, MediaEpisode> | null;
+}
+
+export interface MediaItem {
+  name: string;
+  original_name: string | null;
+  alternative_name: string | null;
+  year: string;
+  category: string;
+  id_kp: string | null;
+  alternative_id_kp: string | null;
+  id_imdb: string | null;
+  id_world_art: string | null;
+  seasons_count?: string | null;
+  quality?: string | null;
+  translation?: string | null;
+  country?: string | null;
+  genre?: string | null;
+  actors?: string | null;
+  directors?: string | null;
+  producers?: string | null;
+  premiere_ru?: string | null;
+  premiere?: string | null;
+  age_restrictions?: string | null;
+  rating_mpaa?: string | null;
+  rating_kp?: string | null;
+  rating_imdb?: string | null;
+  time?: string | null;
+  tagline?: string | null;
+  poster?: string | null;
+  description?: string | null;
+  iframe?: string | null;
+  iframe_last?: string | null;
+  seasons?: Record<string, MediaSeason> | null;
+  translation_iframe?: Record<string, MediaTranslationOption> | null;
+}
+
+export interface ApiSuccessResponse<T> {
+  status: "success";
+  data: T;
+}
+
+export interface ApiErrorResponse {
+  status: "error";
+  error_info: string;
+}
+
+export type ApiResponse<T> = ApiSuccessResponse<T> | ApiErrorResponse;
+
+export interface MediaListParams {
+  list?: "movie" | "serial" | "anime" | "anime-serial" | "tv-show";
+  name?: string;
+  year?: string;
+  order?: string;
+  order_type?: "ASC" | "DESC";
+  translation_name?: string;
+  translation_id?: string;
+  country?: string;
+  not_country?: string;
+  actor?: string;
+  director?: string;
+  producer?: string;
+  rating_kp?: string;
+  rating_imdb?: string;
+  poster?: "0" | "1";
+  description?: "0" | "1";
+  uhd?: string;
+  page?: string;
+}
+
+export interface MediaLookupParams {
+  kp?: string;
+  imdb?: string;
+  world_art?: string;
+  name?: string;
+  year?: string;
+}


### PR DESCRIPTION
## Summary
- replace the web client with a Videobalancer-powered cinema experience featuring search, catalog results, and detailed playback view
- add typed API client utilities for Videobalancer and wire the player to translation selections
- refresh the layout and styling to match a dark themed streaming interface

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68fcd746aeb48328a4c0734185abe99e